### PR TITLE
feat(router): options for disable some errors for audit log

### DIFF
--- a/packages/core/src/defaults.ts
+++ b/packages/core/src/defaults.ts
@@ -98,7 +98,7 @@ export const router: Partial<RouterConfig> = {
     /**
      * Enabled plugins
      */
-    register: [autoSchema, auditLog],
+    register: [autoSchema, auditLog()],
   },
 }
 

--- a/packages/core/src/plugins/router/extensions/audit/log.ts
+++ b/packages/core/src/plugins/router/extensions/audit/log.ts
@@ -1,7 +1,7 @@
 import is = require('is')
 import { Microfleet } from '../../../..'
 import { ServiceRequest, MserviceError } from '../../../../types'
-import { LifecyclePoints } from '..'
+import { LifecyclePoints, ExtensionPlugin } from '..'
 
 export interface AuditLogExtension {
   auditLog: {
@@ -12,47 +12,58 @@ export interface AuditLogExtension {
 
 export type ServiceRequestWithAuditLog = ServiceRequest & AuditLogExtension
 
-export default [
-  {
-    point: LifecyclePoints.preRequest,
-    async handler(route: string, request: ServiceRequestWithAuditLog) {
-      request.auditLog = { start: process.hrtime() }
-      return [route, request]
+export type AuditLogExtensionParams = {
+  disableLogErrorsForNames?: string[],
+}
+
+export default function auditLogFactory(params: AuditLogExtensionParams = {}): ExtensionPlugin[] {
+  const disableLogErrorsForNames: string[] = params.disableLogErrorsForNames || []
+
+  return [
+    {
+      point: LifecyclePoints.preRequest,
+      async handler(route: string, request: ServiceRequestWithAuditLog) {
+        request.auditLog = { start: process.hrtime() }
+        return [route, request]
+      },
     },
-  },
-  {
-    point: LifecyclePoints.preResponse,
-    async handler(this: Microfleet, error: MserviceError | void, result: any, request: ServiceRequestWithAuditLog) {
-      const service = this
-      const execTime = request.auditLog.execTime = process.hrtime(request.auditLog.start)
+    {
+      point: LifecyclePoints.preResponse,
+      async handler(this: Microfleet, error: MserviceError | void, result: any, request: ServiceRequestWithAuditLog) {
+        const service = this
+        const execTime = request.auditLog.execTime = process.hrtime(request.auditLog.start)
 
-      const meta = {
-        headers: request.headers,
-        latency: (execTime[0] * 1000) + (+(execTime[1] / 1000000).toFixed(3)),
-        method: request.method,
-        params: request.params,
-        query: request.query,
-        route: request.route,
-        transport: request.transport,
-        response: undefined,
-      }
-
-      if (error) {
-        const err = is.fn(error.toJSON) ? error.toJSON() : error.toString()
-        const level = error.statusCode && error.statusCode < 400 ? 'info' : 'error'
-        // @ts-ignore
-        meta.err = error
-        // just pass data through
-        request.log[level](meta, 'Error performing operation', err)
-      } else {
-        if (service.config.debug) {
-          meta.response = result
+        const meta = {
+          headers: request.headers,
+          latency: (execTime[0] * 1000) + (+(execTime[1] / 1000000).toFixed(3)),
+          method: request.method,
+          params: request.params,
+          query: request.query,
+          route: request.route,
+          transport: request.transport,
+          response: undefined,
         }
 
-        request.log.info(meta, 'completed operation', request.action.actionName)
-      }
+        if (error) {
+          const err = is.fn(error.toJSON) ? error.toJSON() : error.toString()
+          const isCodeLevelInfo = (error.statusCode && error.statusCode < 400)
+            || (error.name && disableLogErrorsForNames.includes(error.name))
+          const level = isCodeLevelInfo ? 'info' : 'error'
 
-      return [error, result]
+          // @ts-ignore
+          meta.err = error
+          // just pass data through
+          request.log[level](meta, 'Error performing operation', err)
+        } else {
+          if (service.config.debug) {
+            meta.response = result
+          }
+
+          request.log.info(meta, 'completed operation', request.action.actionName)
+        }
+
+        return [error, result]
+      },
     },
-  },
-]
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3188,7 +3188,7 @@ debug@^4.0.0, debug@^4.1.0, debug@~4.1.0:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -4836,7 +4836,7 @@ import-local@^1.0.0:
     pkg-dir "^2.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -6303,11 +6303,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -6316,32 +6311,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@~3.0.0:
   version "3.0.0"
@@ -6447,11 +6420,6 @@ lodash.reduce@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.reduce/-/lodash.reduce-4.6.0.tgz#f1ab6b839299ad48f784abbf476596f03b914d3b"
   integrity sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -8703,7 +8671,7 @@ readable-stream@~1.1.10:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
   integrity sha1-n6+jfShr5dksuuve4DDcm19AZ0c=


### PR DESCRIPTION
BREAKING CHANGE: `routerExtension('audit/log')` returns a constructor