### PR TITLE
fix(http): set default handler to hapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Creates bunyan logger, with streams based on passed configuration and extends mi
 
 Initializes router, which scans folders for actions and builds routing tree for for enabled transports.
 Router controls request lifecycle, which tries to mimic hapi.js lifecycle as closely as possible, with unified interface for multiple transports.
-Currently supports `AMQP` (`@microfleet/transport-amqp`), `HTTP` (`hapi.js`, `express.js,` `restify`) and `Socket.IO`.
+Currently supports `AMQP` (`@microfleet/transport-amqp`), `HTTP` (`hapi.js`) and `Socket.IO`.
 Default sensible configurations are provided.
 
 Stock configuration looks for all `**/*.js` files in `src/actions` directory, enables `hapi.js` based HTTP handler on port 3000.

--- a/packages/core/schemas/http.json
+++ b/packages/core/schemas/http.json
@@ -18,7 +18,7 @@
                     "type": "boolean"
                 },
                 "handler": {
-                    "default": "express",
+                    "default": "hapi",
                     "type": "string"
                 },
                 "handlerConfig": {


### PR DESCRIPTION
Since `express` handler is no longer supported, I suggest to set the only `hapi` handler as default one.