### PR TITLE
fix: correct interfaces + extra types

### DIFF
--- a/packages/plugin-kafka/__tests__/docker-compose.yml
+++ b/packages/plugin-kafka/__tests__/docker-compose.yml
@@ -3,8 +3,6 @@ version: '3'
 services:
   zookeeper:
     image: confluentinc/cp-zookeeper
-    ports:
-      - "2181:2181"
     expose:
       - "2181"
     environment:
@@ -15,8 +13,6 @@ services:
     image: confluentinc/cp-kafka
     depends_on:
       - zookeeper
-    ports:
-      - "9092:9092"
     expose:
       - "9092"
     environment:

--- a/packages/plugin-kafka/package.json
+++ b/packages/plugin-kafka/package.json
@@ -43,5 +43,10 @@
     "@types/sinon": "^7.5.0",
     "toxiproxy-node-client": "^2.0.6",
     "ts-jest": "^24.3.0"
-  }
+  },
+  "files": [
+    "lib/",
+    "src/",
+    "schemas/"
+  ]
 }

--- a/packages/plugin-kafka/src/kafka.ts
+++ b/packages/plugin-kafka/src/kafka.ts
@@ -24,6 +24,8 @@ import {
   KafkaConfig,
 } from './types'
 
+import './rdkafka-extra-types'
+
 import { getLogFnName } from './log-mapping'
 
 /**
@@ -51,11 +53,14 @@ export interface KafkaStreamOpts<T> {
   topicConf?: TopicConfig
 }
 
+export interface KafkaPlugin {
+  kafka: KafkaFactoryInterface
+}
+
 /**
  * Defines service extension
  */
-export interface KafkaPlugin {
-  rdKafkaConfig: KafkaConfig
+export interface KafkaFactoryInterface {
   createConsumerStream(opts: KafkaStreamOpts<ConsumerStreamOptions>): Promise<ConsumerStream>
   createProducerStream(opts: KafkaStreamOpts<ProducerStreamOptions>): Promise<ProducerStream>
   close(): Promise<void>
@@ -69,7 +74,7 @@ export type StreamOptions<T> = T extends ConsumerStream
     ? ProducerStreamOptions
     : never
 
-export class KafkaFactory implements KafkaPlugin {
+export class KafkaFactory implements KafkaFactoryInterface {
   rdKafkaConfig: KafkaConfig
   private streams: Set<KafkaStream>
   private connections: Set<KafkaClient>

--- a/packages/plugin-kafka/src/rdkafka-extra-types.ts
+++ b/packages/plugin-kafka/src/rdkafka-extra-types.ts
@@ -1,14 +1,13 @@
-import { Readable, Writable } from 'stream'
 import { EventEmitter } from 'events'
 import { ConnectOptions } from './types'
 
 declare module 'node-rdkafka' {
-  interface ProducerStream extends Writable {
+  interface ProducerStream extends WritableStream {
     closeAsync(): Promise<void>
     writeAsync(chunk: any, cb?: (e: Error) => void): Promise<void>
   }
 
-  interface ConsumerStream extends Readable {
+  interface ConsumerStream extends ReadableStream {
     closeAsync(): Promise<void>
   }
 

--- a/packages/plugin-kafka/src/rdkafka-extra-types.ts
+++ b/packages/plugin-kafka/src/rdkafka-extra-types.ts
@@ -1,13 +1,16 @@
 import { EventEmitter } from 'events'
+import { Readable, Writable } from 'stream'
+
 import { ConnectOptions } from './types'
 
+// We're extending types defined in https://github.com/Blizzard/node-rdkafka/blob/master/index.d.ts
+// So types should be same
 declare module 'node-rdkafka' {
-  interface ProducerStream extends WritableStream {
+  interface ProducerStream extends Writable {
     closeAsync(): Promise<void>
-    writeAsync(chunk: any, cb?: (e: Error) => void): Promise<void>
   }
 
-  interface ConsumerStream extends ReadableStream {
+  interface ConsumerStream extends Readable {
     closeAsync(): Promise<void>
   }
 

--- a/packages/plugin-kafka/src/rdkafka-extra-types.ts
+++ b/packages/plugin-kafka/src/rdkafka-extra-types.ts
@@ -1,16 +1,18 @@
-import { Client, Producer, KafkaConsumer, ProducerStream, ConsumerStream } from 'node-rdkafka'
+import { Readable, Writable } from 'stream'
+import { EventEmitter } from 'events'
 import { ConnectOptions } from './types'
 
 declare module 'node-rdkafka' {
   interface ProducerStream extends Writable {
     closeAsync(): Promise<void>
+    writeAsync(chunk: any, cb?: (e: Error) => void): Promise<void>
   }
 
   interface ConsumerStream extends Readable {
     closeAsync(): Promise<void>
   }
 
-  interface Client extends NodeJS.EventEmitter {
+  interface Client extends EventEmitter {
     connectAsync(metadataOptions: ConnectOptions): Promise<this>
     disconnectAsync(): Promise<this>
     disconnectAsync(timeout: number): Promise<this>


### PR DESCRIPTION
Some cleanup. Extra types for easier promisified methods access.
Don't know why, but modules.d.ts with overrides was skipped.