### PR TITLE
fix: microfleet/validation version bump

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -73,7 +73,7 @@
     "yargs-parser": "^16.1.0"
   },
   "peerDependencies": {
-    "@microfleet/validation": "~8.x.x",
+    "@microfleet/validation": "^9.0.1",
     "common-errors": "^1.x.x"
   },
   "devDependencies": {
@@ -82,7 +82,7 @@
     "@hapi/joi": "^17.1.0",
     "@hapi/vision": "^6.0.0",
     "@microfleet/transport-amqp": "^15.1.4",
-    "@microfleet/validation": "^8.1.2",
+    "@microfleet/validation": "^9.0.1",
     "@sentry/node": "^5.11.1",
     "@types/bluebird": "^3.5.29",
     "@types/bluebird-retry": "^0.11.4",

--- a/packages/core/src/plugins/amqp.ts
+++ b/packages/core/src/plugins/amqp.ts
@@ -4,7 +4,7 @@ import Errors = require('common-errors')
 import eventToPromise = require('event-to-promise')
 import { NotFoundError } from 'common-errors'
 import get = require('get-value')
-import { ActionTransport, Microfleet, PluginTypes } from '../'
+import { ActionTransport, Microfleet, PluginTypes, LoggerPlugin, ValidatorPlugin } from '../'
 import _require from '../utils/require'
 import getAMQPRouterAdapter from './amqp/router/adapter'
 import verifyPossibility from './router/verifyAttachPossibility'
@@ -48,13 +48,13 @@ export const priority = 0
  * Attaches plugin to the MService class.
  * @param {Object} config - AMQP plugin configuration.
  */
-export function attach(this: Microfleet, opts: any = {}) {
+export function attach(this: Microfleet & LoggerPlugin & ValidatorPlugin, opts: any = {}) {
   const service = this
 
   assert(service.hasPlugin('logger'), new NotFoundError('log module must be included'))
   assert(service.hasPlugin('validator'), new NotFoundError('validator module must be included'))
 
-  const config = service.ifError('amqp', opts)
+  const config = service.validator.ifError('amqp', opts)
   const AMQPTransport = _require('@microfleet/transport-amqp') as any
   const Backoff = require('@microfleet/transport-amqp/lib/utils/recovery')
 

--- a/packages/core/src/plugins/cassandra.ts
+++ b/packages/core/src/plugins/cassandra.ts
@@ -3,7 +3,7 @@ import assert = require('assert')
 import retry = require('bluebird-retry')
 import { NotPermittedError, NotFoundError } from 'common-errors'
 import is = require('is')
-import { Microfleet, LoggerPlugin } from '../'
+import { Microfleet, LoggerPlugin, ValidatorPlugin } from '../'
 import { PluginTypes } from '../constants'
 import _require from '../utils/require'
 
@@ -67,14 +67,14 @@ async function factory(this: Microfleet & LoggerPlugin, Cassandra: any, config: 
   return client
 }
 
-export function attach(this: Microfleet & LoggerPlugin, params: any = {}) {
+export function attach(this: Microfleet & LoggerPlugin & ValidatorPlugin, params: any = {}) {
   const service = this
   const Cassandra = _require('express-cassandra')
 
   assert(service.hasPlugin('logger'), new NotFoundError('log module must be included'))
   assert(service.hasPlugin('validator'), new NotFoundError('validator module must be included'))
 
-  const config = service.ifError('cassandra', params)
+  const config = service.validator.ifError('cassandra', params)
 
   async function connectCassandra() {
     assert(!service.cassandra, new NotPermittedError('Cassandra was already started'))

--- a/packages/core/src/plugins/elasticsearch.ts
+++ b/packages/core/src/plugins/elasticsearch.ts
@@ -4,7 +4,7 @@ import Bluebird = require('bluebird')
 import Errors = require('common-errors')
 import Elasticsearch = require('elasticsearch')
 import { NotFoundError } from 'common-errors'
-import { Microfleet, PluginInterface } from '../'
+import { Microfleet, PluginInterface, ValidatorPlugin, LoggerPlugin } from '../'
 import { PluginTypes } from '../constants'
 
 interface ElasticLogger {
@@ -23,13 +23,13 @@ interface ElasticLogger {
 export const priority = 0
 export const name = 'elasticsearch'
 export const type = PluginTypes.database
-export function attach(this: Microfleet, params: any = {}): PluginInterface {
+export function attach(this: Microfleet & LoggerPlugin & ValidatorPlugin, params: any = {}): PluginInterface {
   const service = this
 
   assert(service.hasPlugin('logger'), new NotFoundError('logger module must be included'))
   assert(service.hasPlugin('validator'), new NotFoundError('validator module must be included'))
 
-  const conf = service.ifError('elasticsearch', params)
+  const conf = service.validator.ifError('elasticsearch', params)
   const { log, ...opts } = conf
   const { log: serviceLogger } = service
 

--- a/packages/core/src/plugins/http.ts
+++ b/packages/core/src/plugins/http.ts
@@ -1,6 +1,6 @@
 import assert = require('assert')
 import { NotFoundError } from 'common-errors'
-import { Microfleet, PluginTypes } from '../'
+import { Microfleet, PluginTypes, ValidatorPlugin } from '../'
 
 /**
  * Plugin Name
@@ -21,16 +21,17 @@ export const priority = 0
  * Attaches HTTP handler.
  * @param config - HTTP handler configuration to attach.
  */
-export function attach(this: Microfleet, opts: any = {}) {
+export function attach(this: Microfleet & ValidatorPlugin, opts: any = {}) {
   const service = this
+  const { validator } = service
 
   assert(service.hasPlugin('validator'), new NotFoundError('validator module must be included'))
 
-  const config = service.ifError('http', opts)
+  const config = validator.ifError('http', opts)
 
   // server specific config
   if (config.server && config.server.handlerConfig) {
-    config.server.handlerConfig = service.ifError(`http.${config.server.handler}`, config.server.handlerConfig)
+    config.server.handlerConfig = validator.ifError(`http.${config.server.handler}`, config.server.handlerConfig)
   }
 
   const handler = require(`./http/handlers/${config.server.handler}`).default

--- a/packages/core/src/plugins/logger.ts
+++ b/packages/core/src/plugins/logger.ts
@@ -94,7 +94,7 @@ export function attach(this: Microfleet & ValidatorPlugin, opts: Partial<LoggerC
   const { config: { name: applicationName } } = service
 
   assert(service.hasPlugin('validator'), new NotFoundError('validator module must be included'))
-  const config = service.ifError('logger', opts) as LoggerConfig
+  const config = service.validator.ifError('logger', opts) as LoggerConfig
 
   const {
     debug,

--- a/packages/core/src/plugins/opentracing.ts
+++ b/packages/core/src/plugins/opentracing.ts
@@ -1,6 +1,6 @@
 import assert = require('assert')
 import { NotFoundError } from 'common-errors'
-import { Microfleet, PluginTypes } from '../'
+import { Microfleet, PluginTypes, ValidatorPlugin } from '../'
 import _require from '../utils/require'
 
 /**
@@ -22,12 +22,12 @@ export const priority = 50
  * Attaches plugin to the MService class.
  * @param settings - AMQP plugin configuration.
  */
-export function attach(this: Microfleet, opts: any = {}) {
+export function attach(this: Microfleet & ValidatorPlugin, opts: any = {}) {
   const service = this
   const { initTracer } = _require('jaeger-client')
 
   assert(service.hasPlugin('logger'), new NotFoundError('log module must be included'))
-  const settings = service.ifError('opentracing', opts)
+  const settings = service.validator.ifError('opentracing', opts)
 
   // init tracer
   service.tracer = initTracer(settings.config, {

--- a/packages/core/src/plugins/prometheus.ts
+++ b/packages/core/src/plugins/prometheus.ts
@@ -1,6 +1,6 @@
 import { createServer } from 'http'
 import assert = require('assert')
-import { Microfleet, PluginTypes } from '..'
+import { Microfleet, PluginTypes, RouterPlugin, ValidatorPlugin } from '..'
 import { getVersion } from '../utils/packageInfo'
 import semver = require('semver')
 import Bluebird = require('bluebird')
@@ -36,7 +36,7 @@ export const priority = 50
  * Attaches plugin to the MService class.
  * @param settings - prometheus settings
  */
-export function attach(this: Microfleet, opts: any = {}) {
+export function attach(this: Microfleet & RouterPlugin & ValidatorPlugin, opts: any = {}) {
   const service = this
 
   if (service.config.plugins.includes('router')) {
@@ -46,7 +46,7 @@ export function attach(this: Microfleet, opts: any = {}) {
 
   const prometheus = service.prometheus = require('prom-client')
 
-  const { config } = service.ifError(name, opts)
+  const { config } = service.validator.ifError(name, opts)
   const { port, path, durationBuckets } = config
 
   // register default metrics

--- a/packages/core/src/plugins/redisCluster.ts
+++ b/packages/core/src/plugins/redisCluster.ts
@@ -2,7 +2,7 @@ import assert = require('assert')
 import Bluebird = require('bluebird')
 import _debug = require('debug')
 import eventToPromise = require('event-to-promise')
-import { Microfleet, PluginTypes } from '../'
+import { Microfleet, PluginTypes, ValidatorPlugin } from '../'
 import _require from '../utils/require'
 import migrate from './redis/migrate'
 import { NotFoundError } from 'common-errors'
@@ -30,7 +30,7 @@ export const priority = 0
  * @param  [conf={}] - Configuration for Redis Cluster Connection.
  * @returns Connections and Destructors.
  */
-export function attach(this: Microfleet, opts: any = {}) {
+export function attach(this: Microfleet & ValidatorPlugin, opts: any = {}) {
   const service = this
   const Redis = _require('ioredis')
   const { ERROR_NOT_STARTED, ERROR_ALREADY_STARTED } = require('./redis/constants')
@@ -45,7 +45,7 @@ export function attach(this: Microfleet, opts: any = {}) {
 
   const { Cluster } = Redis
   const isClusterStarted = isStarted(service, Cluster)
-  const conf = service.ifError('redisCluster', opts)
+  const conf = service.validator.ifError('redisCluster', opts)
 
   return {
 

--- a/packages/core/src/plugins/redisSentinel.ts
+++ b/packages/core/src/plugins/redisSentinel.ts
@@ -1,7 +1,7 @@
 import assert = require('assert')
 import Bluebird = require('bluebird')
 import _debug = require('debug')
-import { Microfleet, PluginTypes } from '../'
+import { Microfleet, PluginTypes, ValidatorPlugin } from '../'
 import _require from '../utils/require'
 import { ERROR_ALREADY_STARTED, ERROR_NOT_STARTED } from './redis/constants'
 import { NotFoundError } from 'common-errors'
@@ -30,7 +30,7 @@ export const priority = 0
  * @param  [conf={}] - Configuration for Redis Sentinel Connection.
  * @returns Connections and Destructors.
  */
-export function attach(this: Microfleet, opts: any = {}) {
+export function attach(this: Microfleet & ValidatorPlugin, opts: any = {}) {
   const service = this
   const Redis = _require('ioredis')
 
@@ -38,7 +38,7 @@ export function attach(this: Microfleet, opts: any = {}) {
 
   Redis.Promise = Bluebird
   const isRedisStarted = isStarted(service, Redis)
-  const conf = service.ifError('redisSentinel', opts)
+  const conf = service.validator.ifError('redisSentinel', opts)
 
   return {
 

--- a/packages/core/src/plugins/router.ts
+++ b/packages/core/src/plugins/router.ts
@@ -84,7 +84,7 @@ export function attach(this: Microfleet & ValidatorPlugin & LoggerPlugin & Route
 
   assert(service.hasPlugin('logger'), new NotFoundError('log module must be included'))
   assert(service.hasPlugin('validator'), new NotFoundError('validator module must be included'))
-  const config = service.ifError('router', opts) as RouterConfig
+  const config = service.validator.ifError('router', opts) as RouterConfig
 
   for (const transport of config.routes.transports) {
     if (!service.config.plugins.includes(transport) && transport !== internal) {

--- a/packages/core/src/plugins/socketIO.ts
+++ b/packages/core/src/plugins/socketIO.ts
@@ -2,7 +2,7 @@ import assert = require('assert')
 import { NotImplementedError, NotFoundError } from 'common-errors'
 import _debug = require('debug')
 import is = require('is')
-import { ActionTransport, Microfleet, PluginTypes } from '../'
+import { ActionTransport, Microfleet, PluginTypes, ValidatorPlugin } from '../'
 import _require from '../utils/require'
 import attachRouter from './socketIO/router/attach'
 import * as RequestTracker from './router/request-tracker'
@@ -13,7 +13,7 @@ interface AdaptersList {
   [name: string]: any
 }
 
-function attachSocketIO(this: Microfleet, opts: any = {}) {
+function attachSocketIO(this: Microfleet & ValidatorPlugin, opts: any = {}) {
   debug('Attaching socketIO plugin')
   const service = this
   const AdapterFactory = _require('ms-socket.io-adapter-amqp')
@@ -25,7 +25,7 @@ function attachSocketIO(this: Microfleet, opts: any = {}) {
     amqp: (adapterOptions: any) => AdapterFactory.fromOptions(adapterOptions),
   }
 
-  const config = service.ifError('socketIO', opts)
+  const config = service.validator.ifError('socketIO', opts)
   const { options, router } = config
   const { adapter } = options
 

--- a/packages/core/src/plugins/validator.ts
+++ b/packages/core/src/plugins/validator.ts
@@ -5,6 +5,7 @@ import { NotPermittedError } from 'common-errors'
 import path = require('path')
 import { strictEqual } from 'assert'
 import { isString, isPlainObject, isFunction } from 'lodash'
+import { deprecate } from 'util'
 
 import { Microfleet } from '../'
 import { PluginTypes } from '../constants'
@@ -36,6 +37,9 @@ export const name = 'validator'
  */
 export interface ValidatorPlugin {
   validator: Validator
+  validate: Validator['validate']
+  validateSync: Validator['validateSync']
+  ifError:  Validator['ifError']
 }
 
 /**
@@ -119,4 +123,7 @@ export const attach = function attachValidator(
   // extend service
   service[name] = validator
   service[name].addLocation = addLocation
+  service.validate = deprecate(validator.validate.bind(validator), 'validate() deprecated. User validator.validate()')
+  service.validateSync = deprecate(validator.validateSync.bind(validator), 'validateSync() deprecated. User validator.validateSync()')
+  service.ifError = deprecate(validator.ifError.bind(validator), 'ifError() deprecated. User validator.ifError()')
 }

--- a/packages/core/src/plugins/validator.ts
+++ b/packages/core/src/plugins/validator.ts
@@ -120,7 +120,9 @@ export const attach = function attachValidator(
   // extend service
   service[name] = validator
   service[name].addLocation = addLocation
-  service.validate = validator.validate
-  service.validateSync = validator.validateSync
-  service.ifError = validator.ifError
+
+  // @microfleet/validation >= 9.0.1 requires method to be bound to validator instance
+  service.validate = validator.validate.bind(validator)
+  service.validateSync = validator.validateSync.bind(validator)
+  service.ifError = validator.ifError.bind(validator)
 }

--- a/packages/core/src/plugins/validator.ts
+++ b/packages/core/src/plugins/validator.ts
@@ -1,4 +1,4 @@
-import Validator from '@microfleet/validation'
+import MicrofleetValidator from '@microfleet/validation'
 import ajv from 'ajv'
 import callsite = require('callsite')
 import { NotPermittedError } from 'common-errors'
@@ -10,6 +10,10 @@ import { Microfleet } from '../'
 import { PluginTypes } from '../constants'
 
 const { isArray } = Array
+
+type Validator = MicrofleetValidator & {
+  addLocation(location: string): void
+}
 
 /**
  * Validator configuration, more details in
@@ -31,12 +35,7 @@ export const name = 'validator'
  * Defines service extension
  */
 export interface ValidatorPlugin {
-  validator: Validator & {
-    addLocation(location: string): void
-  }
-  validate: Validator['validate']
-  validateSync: Validator['validateSync']
-  ifError:  Validator['ifError']
+  validator: Validator
 }
 
 /**
@@ -74,7 +73,7 @@ export const attach = function attachValidator(
   strictEqual(filter === null || isFunction(filter), true, configError('filter'))
   strictEqual(isPlainObject(ajvConfig), true, configError('ajvConfig'))
 
-  const validator = new Validator('../../schemas', filter, ajvConfig)
+  const validator = new MicrofleetValidator('../../schemas', filter, ajvConfig)
   const addLocation = (location: string) => {
     strictEqual(isString(location) && location.length !== 0, true, configError('schemas'))
 
@@ -120,9 +119,4 @@ export const attach = function attachValidator(
   // extend service
   service[name] = validator
   service[name].addLocation = addLocation
-
-  // @microfleet/validation >= 9.0.1 requires method to be bound to validator instance
-  service.validate = validator.validate.bind(validator)
-  service.validateSync = validator.validateSync.bind(validator)
-  service.ifError = validator.ifError.bind(validator)
 }

--- a/packages/core/test/suites/validator.js
+++ b/packages/core/test/suites/validator.js
@@ -23,10 +23,11 @@ describe('Validator suite', () => {
   });
 
   it('validator exposes validate methods on the service', function test() {
-    assert(this.service.validate);
-    assert(this.service.validateSync);
-    assert(typeof this.service.validate === 'function');
-    assert(typeof this.service.validateSync === 'function');
+    const { validator } = this.service;
+    assert(validator.validate);
+    assert(validator.validateSync);
+    assert(typeof validator.validate === 'function');
+    assert(typeof validator.validateSync === 'function');
   });
 
   it('validator throw on invalid config when `config` schema is present', function test() {
@@ -55,7 +56,7 @@ describe('Validator suite', () => {
     });
 
     assert(!!this.service.validator.ajv.getSchema('test-schema'));
-    assert.equal(this.service.validateSync('test-types-schema', '1').doc, '1');
+    assert.equal(this.service.validator.validateSync('test-types-schema', '1').doc, '1');
     assert(!!this.service.validator.ajv.getSchema('config'));
   });
 });

--- a/packages/plugin-consul/package.json
+++ b/packages/plugin-consul/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/microfleet/core#readme",
   "peerDependencies": {
-    "@microfleet/core": "~15.x.x"
+    "@microfleet/core": "~16.x.x"
   },
   "devDependencies": {
     "@microfleet/core": "^16.0.4",

--- a/packages/plugin-consul/src/plugin.ts
+++ b/packages/plugin-consul/src/plugin.ts
@@ -40,11 +40,10 @@ export const priority = 0
 
 /**
  * Attaches initialized validator based on conf.
- * Provides `validate` and `validateSync` methods.
- * @param conf - Validator Configuration Object.
- * @param parentFile - From which file this plugin was invoked.
+ * Provides `consul` and `consulLeader` methods.
+ * @param conf - Consul Configuration Object.
  */
-export const attach = function attachValidator(
+export const attach = function attachConsulPlugin(
   this: Microfleet & ValidatorPlugin & LoggerPlugin & ConsulPlugin,
   opts: Partial<ConsulConfig> = {}
 ): PluginInterface {
@@ -56,7 +55,7 @@ export const attach = function attachValidator(
   // load local schemas
   service.validator.addLocation(resolve(__dirname, '../schemas'))
 
-  const config = service.ifError(name, opts) as ConsulConfig
+  const config = service.validator.ifError(name, opts) as ConsulConfig
   const base = { ...config.base, promisify: true }
   const lockConfig = {
     key: `microfleet/${service.config.name}/leader`,

--- a/packages/plugin-couchdb/package.json
+++ b/packages/plugin-couchdb/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/microfleet/core#readme",
   "peerDependencies": {
-    "@microfleet/core": "~15.x.x"
+    "@microfleet/core": "~16.x.x"
   },
   "dependencies": {
     "nano": "apache/couchdb-nano#4fed1e50488479596e4b2e440d96040c2dc72e36"

--- a/packages/plugin-kafka/package.json
+++ b/packages/plugin-kafka/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/microfleet/core#readme",
   "peerDependencies": {
-    "@microfleet/core": "~15.x.x"
+    "@microfleet/core": "~16.x.x"
   },
   "dependencies": {
     "@microfleet/core": "^16.0.4",

--- a/packages/plugin-kafka/src/kafka.ts
+++ b/packages/plugin-kafka/src/kafka.ts
@@ -1,7 +1,7 @@
 import assert = require('assert')
 import { resolve } from 'path'
 import { NotFoundError } from 'common-errors'
-import { Microfleet, PluginTypes, PluginInterface, LoggerPlugin } from '@microfleet/core'
+import { Microfleet, PluginTypes, PluginInterface, LoggerPlugin, ValidatorPlugin } from '@microfleet/core'
 import { promisifyAll, map } from 'bluebird'
 
 import {
@@ -170,7 +170,7 @@ export class KafkaFactory implements KafkaFactoryInterface {
  * @param params - Kafka configuration.
  */
 export function attach(
-  this: Microfleet & LoggerPlugin,
+  this: Microfleet & LoggerPlugin & ValidatorPlugin,
   params: KafkaConfig
 ): PluginInterface {
   const service = this
@@ -181,7 +181,7 @@ export function attach(
   // load local schemas
   service.validator.addLocation(resolve(__dirname, '../schemas'))
 
-  const conf: KafkaConfig = service.ifError(name, params)
+  const conf: KafkaConfig = service.validator.ifError(name, params)
   const kafkaPlugin = service[name] = new KafkaFactory(service, conf)
 
   return {

--- a/packages/plugin-knex/package.json
+++ b/packages/plugin-knex/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/microfleet/core#readme",
   "peerDependencies": {
-    "@microfleet/core": "~15.x.x"
+    "@microfleet/core": "~16.x.x"
   },
   "dependencies": {
     "knex": "^0.20.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1612,18 +1612,17 @@
     pino "^5.14.0"
     uuid "^3.3.3"
 
-"@microfleet/validation@^8.1.2":
-  version "8.1.2"
-  resolved "https://registry.yarnpkg.com/@microfleet/validation/-/validation-8.1.2.tgz#fa18706e5ca8b9e1adb86b41d8145e175f435334"
-  integrity sha512-us1FKuYSVplFrLp5nPrTsNUkLs+fyzkXhPSeEXWdRx5/FmzqgG67Rop3ZVK42YIt+qDpk65ncLFYPHTu1+nv+Q==
+"@microfleet/validation@^9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@microfleet/validation/-/validation-9.0.1.tgz#e55d41402d9706ac76afa446dbcc54aa5f177167"
+  integrity sha512-eKnfEPu6yIoargkihNlcqlQ8xT6p/jeu5PlPd4V8zE7vfHVR5U6ysFLiRufKuYAH1AaIH4zigJ8qMGWzRtwb3g==
   dependencies:
-    ajv "^6.6.2"
+    ajv "^6.12.0"
     ajv-keywords "^3.2.0"
-    bluebird "^3.5.3"
     callsite "^1.0.0"
     common-errors "^1.0.5"
     debug "^4.1.1"
-    glob "^7.1.3"
+    glob "^7.1.6"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -2502,10 +2501,20 @@ ajv-keywords@^3.2.0:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.1.tgz#ef916e271c64ac12171fd8384eaae6b2345854da"
   integrity sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==
 
-ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.5, ajv@^6.6.2:
+ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.5:
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.11.0.tgz#c3607cbc8ae392d8a5a536f25b21f8e5f3f87fe9"
   integrity sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^6.12.0:
+  version "6.12.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.0.tgz#06d60b96d87b8454a5adaba86e7854da629db4b7"
+  integrity sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"


### PR DESCRIPTION
This fix restores bumps `@microfleet/validation` version and fixes compatibility.

As an addition, I'd recomend to remove additional properties from Microfleet base class that `validator` plugin adds. https://github.com/microfleet/core/blob/master/packages/core/src/plugins/validator.ts#L37-L39.

This will allow to skip context rebinding in `validator` plugin for `validate`, `validateSync`, `ifError` methods when Plugin assignes them to the `Microfleet` instance.

This will take more time to update dependent services and packages, but this will save us from misunderstanging what `validate`, `validateSync`, `ifError` methods do. 

If you don't consider these changes necessary, I will remove the commit https://github.com/microfleet/core/pull/402/commits/008915cc5861bfb742deeab242561a541c2504c6 that removes these methods