### PR TITLE
fix(plugin-kafka): offsetsStore called using lower offsets

### DIFF
--- a/packages/plugin-kafka/src/custom/consumer-stream.ts
+++ b/packages/plugin-kafka/src/custom/consumer-stream.ts
@@ -274,9 +274,10 @@ export class KafkaConsumerStream extends Readable {
       }
 
       this.updatePartitionOffsets([topicPartition], unacknowledgedTracker)
-
-      if (autoStore) this.consumer.offsetsStore([topicPartition])
     }
+
+    // We already have all max offsets inside unacknowledgedTracker. Let's mark them for commit
+    if (autoStore) this.consumer.offsetsStore([...unacknowledgedTracker.values()])
 
     if (this.config.streamAsBatch) {
       this.messages.push(messages)


### PR DESCRIPTION
Sometimes `KafkaConsumer.offsetsStore` was executed with offsets lower than maximum offset of the messages in pack. This happens when messages were received unordered.