### PR TITLE
feat: kafka admin client + some sugar

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   moduleNameMapper: {
-    '@microfleet/plugin-(.*)-types': '<rootDir>/packages/$1',
+    '@microfleet/((?:plugin-).*(?:types))': '<rootDir>/packages/$1',
     '@microfleet/((?:plugin-|core).*)': '<rootDir>/packages/$1/src'
   }
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,7 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   moduleNameMapper: {
+    '@microfleet/plugin-(.*)-types': '<rootDir>/packages/$1',
     '@microfleet/((?:plugin-|core).*)': '<rootDir>/packages/$1/src'
   }
 }

--- a/packages/plugin-kafka-types/index.d.ts
+++ b/packages/plugin-kafka-types/index.d.ts
@@ -1,7 +1,7 @@
 // Extend types defined in https://github.com/Blizzard/node-rdkafka/blob/master/index.d.ts
 import * as kafka from 'node-rdkafka'
 import { Microfleet } from '@microfleet/core'
-import { KafkaFactory, KafkaConsumerStream } from '@microfleet/plugin-kafka'
+import { KafkaFactory, KafkaConsumerStream, GlobalConfig, TopicConfig } from '@microfleet/plugin-kafka'
 import { Writable, Readable } from 'stream'
 
 declare module '@microfleet/core' {
@@ -119,6 +119,9 @@ declare module 'node-rdkafka' {
   }
 
   export interface Client extends EventEmitter {
+    // eslint-disable-next-line @typescript-eslint/no-misused-new
+    new (c: GlobalConfig, tc: TopicConfig): Client<KafkaClientEvents>;
+
     _isDisconnecting: boolean;
 
     // Required on dicsonnection cleanup
@@ -141,5 +144,17 @@ declare module 'node-rdkafka' {
     // https://github.com/Blizzard/node-rdkafka/blob/master/lib/kafka-consumer.js#L176
     committedAsync(toppars: TopicPartition[], timeout: number): Promise<kafka.TopicPartitionOffset[]>;
     consumeAsync(count: number): Promise<kafka.Message[]>;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/interface-name-prefix
+  export interface IAdminClient {
+    createTopicAsync(topic: NewTopic): Promise<void>;
+    createTopicAsync(topic: NewTopic, timeout?: number): Promise<void>;
+
+    deleteTopicAsync(topic: string): Promise<void>;
+    deleteTopicAsync(topic: string, timeout?: number): Promise<void>;
+
+    createPartitionsAsync(topic: string, desiredPartitions: number): Promise<void>;
+    createPartitionsAsync(topic: string, desiredPartitions: number, timeout?: number): Promise<void>;
   }
 }

--- a/packages/plugin-kafka-types/index.d.ts
+++ b/packages/plugin-kafka-types/index.d.ts
@@ -1,7 +1,8 @@
 // Extend types defined in https://github.com/Blizzard/node-rdkafka/blob/master/index.d.ts
 import * as kafka from 'node-rdkafka'
 import { Microfleet } from '@microfleet/core'
-import { KafkaFactory, KafkaConsumerStream, GlobalConfig, TopicConfig } from '@microfleet/plugin-kafka'
+import { GlobalConfig, TopicConfig } from 'node-rdkafka'
+import { KafkaFactory, KafkaConsumerStream } from '@microfleet/plugin-kafka'
 import { Writable, Readable } from 'stream'
 
 declare module '@microfleet/core' {

--- a/packages/plugin-kafka-types/package.json
+++ b/packages/plugin-kafka-types/package.json
@@ -2,6 +2,7 @@
   "name": "@microfleet/plugin-kafka-types",
   "description": "Types for Apache Kafka adapter for microfleet",
   "version": "1.1.1",
+  "main": "./index.d.ts",
   "scripts": {
     "lint": "eslint './**/*.ts'",
     "test": "yarn lint; tsc",

--- a/packages/plugin-kafka/__tests__/suites/kafka.spec.ts
+++ b/packages/plugin-kafka/__tests__/suites/kafka.spec.ts
@@ -79,7 +79,7 @@ describe('#generic', () => {
       expect(consumerStream).toBeDefined()
     })
 
-    test('should be able to get Admin client and create/delete topic', async () => {
+    test.only('should be able to get Admin client and create/delete topic', async () => {
       const { kafka } = service
       const readyTopic = {name: 'manually-created', partitions: [{id: 0, isrs: [1], leader: 1, replicas: [1]}]}
       const topic = 'manually-created'

--- a/packages/plugin-kafka/__tests__/suites/kafka.spec.ts
+++ b/packages/plugin-kafka/__tests__/suites/kafka.spec.ts
@@ -79,7 +79,7 @@ describe('#generic', () => {
       expect(consumerStream).toBeDefined()
     })
 
-    test.only('should be able to get Admin client and create/delete topic', async () => {
+    test('should be able to get Admin client and create/delete topic', async () => {
       const { kafka } = service
       const readyTopic = {name: 'manually-created', partitions: [{id: 0, isrs: [1], leader: 1, replicas: [1]}]}
       const topic = 'manually-created'

--- a/packages/plugin-kafka/src/custom/errors.ts
+++ b/packages/plugin-kafka/src/custom/errors.ts
@@ -47,3 +47,7 @@ export const Generic = {
 }
 
 export const CommitTimeoutError = new TimeoutError('offset commit timeout on shutdown')
+
+export const TopicWaitError = ErrorHelpers.generateClass('TopicWaitError', {
+  args: ['message', 'retryConfig', 'retryState'],
+})

--- a/packages/plugin-kafka/src/custom/rdkafka-extra.ts
+++ b/packages/plugin-kafka/src/custom/rdkafka-extra.ts
@@ -11,6 +11,8 @@ import {
   ConsumerStream,
   ProducerStream,
   LibrdKafkaError as LibrdKafkaError,
+  Client,
+  KafkaClientEvents,
 } from 'node-rdkafka'
 
 export * from 'node-rdkafka'
@@ -22,11 +24,13 @@ export * from 'node-rdkafka'
  */
 export const KafkaProducerStream = require('node-rdkafka/lib/producer-stream') as ProducerStream
 export const KafkaConsumerStream = require('node-rdkafka/lib/kafka-consumer-stream') as ConsumerStream
+export const KafkaClient = require('node-rdkafka/lib/client') as Client<KafkaClientEvents>
 export const LibrdKafkaErrorClass = require('node-rdkafka/lib/error') as LibrdKafkaError
 
 export type KafkaProducerStream = ProducerStream
 export type KafkaConsumerStream = ConsumerStream
 export type LibrdKafkaErrorClass = LibrdKafkaError
+export type KafkaClient = Client<KafkaClientEvents>
 
 promisifyAll(KafkaProducerStream.prototype)
 promisifyAll(KafkaConsumerStream.prototype)

--- a/packages/plugin-kafka/src/kafka.ts
+++ b/packages/plugin-kafka/src/kafka.ts
@@ -94,7 +94,7 @@ export class KafkaFactory {
   }
 
   async createProducerStream(opts: ProducerStreamConfig): Promise<KafkaProducerStream> {
-    const producer = this.createClient(KafkaProducer, opts.conf || {}, opts.topicConf || {})
+    const producer = this.createClient(KafkaProducer, opts.conf, opts.topicConf)
 
     this.attachClientLogger(producer, { type: 'producer', topic: opts.streamOptions.topic })
 
@@ -139,8 +139,8 @@ export class KafkaFactory {
 
   public createClient<T extends KafkaClient, U extends GlobalConfig, Z extends TopicConfig>(
     clientClass: new (c: U, tc: Z) => T,
-    conf: U,
-    topicConf: Z
+    conf: U = {} as U,
+    topicConf: Z = {} as Z
   ): T {
     const config: U = { ...this.rdKafkaConfig as U, ...conf }
     return new clientClass(config, topicConf)

--- a/packages/plugin-kafka/src/kafka.ts
+++ b/packages/plugin-kafka/src/kafka.ts
@@ -25,6 +25,7 @@ import {
 } from './custom/rdkafka-extra'
 import { getLogFnName, topicExists } from './util'
 import { KafkaConsumerStream } from './custom/consumer-stream'
+import { KafkaAdminClient } from './custom/admin-client'
 
 export { OffsetCommitError, UncommittedOffsetsError, TopicNotFoundError } from './custom/errors'
 export { KafkaConsumerStream, KafkaProducerStream, RdKafkaCodes }
@@ -40,7 +41,9 @@ export const type = PluginTypes.transport
 export * from '@microfleet/plugin-kafka-types'
 
 export class KafkaFactory {
-  rdKafkaConfig: GlobalConfig
+  public rdKafkaConfig: GlobalConfig
+  public admin: KafkaAdminClient
+
   private streams: Set<KafkaStream>
   private connections: Set<KafkaClient>
   private service: Microfleet
@@ -50,6 +53,7 @@ export class KafkaFactory {
     this.streams = new Set<KafkaStream>()
     this.connections = new Set<KafkaClient>()
     this.service = service
+    this.admin = new KafkaAdminClient(service, this)
   }
 
   async createConsumerStream(opts: ConsumerStreamConfig): Promise<KafkaConsumerStream> {
@@ -99,6 +103,8 @@ export class KafkaFactory {
   }
 
   async close() {
+    // Disconnect admin client
+    this.admin.close()
     // Some connections will be already closed by streams
     await map(this.streams.values(), stream => stream.closeAsync())
     // Close other connections
@@ -131,7 +137,7 @@ export class KafkaFactory {
     return stream
   }
 
-  private createClient<T extends KafkaClient, U extends GlobalConfig, Z extends TopicConfig>(
+  public createClient<T extends KafkaClient, U extends GlobalConfig, Z extends TopicConfig>(
     clientClass: new (c: U, tc: Z) => T,
     conf: U,
     topicConf: Z
@@ -140,7 +146,7 @@ export class KafkaFactory {
     return new clientClass(config, topicConf)
   }
 
-  private attachClientLogger(client: Client<KafkaClientEvents>, meta: any = {}) {
+  public attachClientLogger(client: Client<KafkaClientEvents>, meta: any = {}) {
     const { log } = this.service
     const { connections } = this
 
@@ -161,6 +167,8 @@ export class KafkaFactory {
       // After this cleanups total leak for 2500 topics will be in about 10Mb.
 
       this['_metadata'] = null
+      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+      // @ts-ignore
       this.globalConfig = null
     })
 

--- a/packages/plugin-logger/src/logger.ts
+++ b/packages/plugin-logger/src/logger.ts
@@ -100,7 +100,7 @@ export interface LoggerConfig {
 }
 
 export const levels = ['trace', 'debug', 'info', 'warn', 'error', 'fatal']
-export const isCompatible = (obj: any): obj is pinoms.Logger => {
+export const isCompatible = (obj: any): obj is pino.Logger => {
   return obj !== null
     && typeof obj === 'object'
     && every(exports.levels, (level: any) => typeof obj[level] === 'function')
@@ -134,7 +134,7 @@ export function attach(this: Microfleet & ValidatorPlugin, opts: Partial<LoggerC
 
   if (defaultLogger === true) {
     // return either human-readable logger or fast production-ready json logger
-    const getDefaultStream = () => {
+    const getDefaultStream = (): NodeJS.WritableStream => {
       if (prettifyDefaultLogger) {
         const { stream } = streamsFactory('pretty', { translateTime: true })
         return stream

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,7 +13,8 @@
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "preserveConstEnums": true,
-    "composite": true
+    "composite": true,
+    "skipLibCheck": true
   },
   "exclude": [
     "**/node_modules/**",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "files": [],
+  "compilerOptions": {
+    "skipLibCheck": true
+  },
   "references": [{
     "path": "./packages/core/tsconfig.build.json"
   }, {


### PR DESCRIPTION
* Provides `KafkaAdmin` client
* Adds ability to control create and delete topic operations. node-rdkafka executes success callbacks before topic operations settled.
