### PR TITLE
fix: change offset_commit_cb logic + error handler

### DIFF
--- a/packages/plugin-kafka/__tests__/helpers/kafka.ts
+++ b/packages/plugin-kafka/__tests__/helpers/kafka.ts
@@ -118,7 +118,7 @@ export function commitBatch(stream: KafkaConsumerStream, msgs: Message[]): void 
   msgs.map((msg: Message) => stream.consumer.commitMessage(msg))
 }
 
-export function msgsToArr(incommingMessage: Message | Message []) {
+export function msgsToArr(incommingMessage: Message | Message []): Message[] {
   return Array.isArray(incommingMessage) ? incommingMessage : [incommingMessage]
 }
 

--- a/packages/plugin-kafka/__tests__/suites/kafka.spec.ts
+++ b/packages/plugin-kafka/__tests__/suites/kafka.spec.ts
@@ -504,6 +504,14 @@ describe('#generic', () => {
     })
 
     describe('executes external offset.commit error handler', () => {
+      const emitError = (stream: KafkaConsumerStream, topicPartition: { topic: string, partition: number, offset: number }) => {
+        stream.consumer.emit(
+          'offset.commit',
+          { code: -168, message: 'Local: no offsets stored' },
+          [ topicPartition ]
+        )
+      }
+
       test('as iterable', async () => {
         const topic = 'test-throw-kafka-error-handler'
 
@@ -534,11 +542,7 @@ describe('#generic', () => {
             if (!errorEmitted && receivedMessages.length === 2) {
               errorEmitted = true
               service.log.debug('EMIT ERROR')
-              consumerStream.consumer.emit(
-                'offset.commit',
-                { code: -168, message: 'Local: no offsets stored' },
-                [{ topic: lastMessage.topic, partition: lastMessage.partition, offset: lastMessage.offset + 1 }]
-              )
+              emitError(consumerStream, { topic: lastMessage.topic, partition: lastMessage.partition, offset: lastMessage.offset + 1 })
             }
             consumerStream.commit()
           }
@@ -579,11 +583,7 @@ describe('#generic', () => {
 
             if (!errorEmitted && receivedMessages.length === 2) {
               errorEmitted = true
-              consumerStream.consumer.emit(
-                'offset.commit',
-                { code: -168, message: 'Local: no offsets stored' },
-                [{ topic: lastMessage.topic, partition: lastMessage.partition, offset: lastMessage.offset + 1 }]
-              )
+              emitError(consumerStream, { topic: lastMessage.topic, partition: lastMessage.partition, offset: lastMessage.offset + 1 })
             }
             consumerStream.commit()
             callback()

--- a/packages/plugin-kafka/src/custom/admin-client.ts
+++ b/packages/plugin-kafka/src/custom/admin-client.ts
@@ -8,16 +8,18 @@ import { TopicWaitError } from './errors'
 import { KafkaClient as KafkaClientType } from '@microfleet/plugin-kafka-types'
 import { KafkaFactory } from '../kafka'
 
+export type RetryOptions = retry.Options
+
 export type CreateTopicRequest = {
   topic: NewTopic;
   client?: KafkaClient;
-  params?: retry.Options;
+  params?: RetryOptions;
 }
 
 export type DeleteTopicRequest = {
   topic: string;
   client?: KafkaClient;
-  params?: retry.Options;
+  params?: RetryOptions;
 }
 
 type WaitCriteria = {

--- a/packages/plugin-kafka/src/kafka.ts
+++ b/packages/plugin-kafka/src/kafka.ts
@@ -28,7 +28,7 @@ import { KafkaConsumerStream } from './custom/consumer-stream'
 import { KafkaAdminClient } from './custom/admin-client'
 
 export { OffsetCommitError, UncommittedOffsetsError, TopicNotFoundError } from './custom/errors'
-export { DeleteTopicRequest, CreateTopicRequest } from './custom/admin-client'
+export { DeleteTopicRequest, CreateTopicRequest, RetryOptions } from './custom/admin-client'
 
 export { KafkaConsumerStream, KafkaProducerStream, RdKafkaCodes }
 


### PR DESCRIPTION
* Changed offset_commit_cb logic - will try to check position even when error happened.
* Added `externalOffsetCommitErrorHandler` to provide to the user an ability to control offset_commit error handling
* Added additional debug logs
* Exposed RetryOptions for Admin interface.