### PR TITLE
fix(plugin-kafka): correct eof handling

### DIFF
--- a/packages/plugin-kafka/__tests__/helpers/kafka.ts
+++ b/packages/plugin-kafka/__tests__/helpers/kafka.ts
@@ -57,7 +57,7 @@ export async function createConsumerStream(
     ({
       streamOptions: {
         streamAsBatch: true,
-        fetchSize: 2,
+        fetchSize: 20,
         stopOnPartitionsEOF: true,
         // waitInterval: 0,
         // wait abit longer for broker queries

--- a/packages/plugin-kafka/__tests__/jest.setup.js
+++ b/packages/plugin-kafka/__tests__/jest.setup.js
@@ -1,2 +1,2 @@
 /* eslint-disable no-undef */
-jest.setTimeout(15000)
+jest.setTimeout(30000)

--- a/packages/plugin-kafka/__tests__/suites/kafka.spec.ts
+++ b/packages/plugin-kafka/__tests__/suites/kafka.spec.ts
@@ -88,7 +88,12 @@ describe('#generic', () => {
 
       const { admin } = kafka
 
-      await admin.createTopic({ topic: { topic, num_partitions: 1, replication_factor: 1 }})
+      await admin.createTopic({
+        topic: { topic, num_partitions: 1, replication_factor: 1 },
+        params: {
+          interval: 1000,
+        }
+      })
       const meta = await producerTemp.producer.getMetadataAsync({ allTopics: true })
       expect(meta.topics).toEqual(
         expect.arrayContaining([
@@ -96,7 +101,13 @@ describe('#generic', () => {
         ])
       )
 
-      await admin.deleteTopic({ topic })
+      await admin.deleteTopic({
+        topic,
+        params: {
+          interval: 1000,
+        },
+      })
+
       const metaAfter = await producerTemp.producer.getMetadataAsync({ topic })
       expect(metaAfter.topics).not.toEqual(
         expect.arrayContaining([

--- a/packages/plugin-kafka/__tests__/suites/kafka.spec.ts
+++ b/packages/plugin-kafka/__tests__/suites/kafka.spec.ts
@@ -295,7 +295,7 @@ describe('#generic', () => {
       const topic = 'test-throw-disconnected-consumer'
 
       producer = await createProducerStream(service)
-      await sendMessages(producer, topic, 10)
+      await sendMessages(producer, topic, 100)
       await producer.closeAsync()
 
       consumerStream = await createConsumerStream(service, {
@@ -320,7 +320,7 @@ describe('#generic', () => {
         }
       }
 
-      expect(receivedMessages).toHaveLength(2)
+      expect(receivedMessages).toHaveLength(20)
     })
 
     describe('on disconnected consumer without auto.commit', () => {
@@ -328,7 +328,7 @@ describe('#generic', () => {
         const topic = 'test-throw-disconnected-consumer-auto-commit'
 
         producer = await createProducerStream(service)
-        await sendMessages(producer, topic, 10)
+        await sendMessages(producer, topic, 100)
         await producer.closeAsync()
 
         consumerStream = await createConsumerStream(service, {
@@ -404,7 +404,7 @@ describe('#generic', () => {
       const topic = 'test-throw-error-commit-timeout'
 
       producer = await createProducerStream(service)
-      await sendMessages(producer, topic, 10)
+      await sendMessages(producer, topic, 100)
 
       consumerStream = await createConsumerStream(service, {
         streamOptions: {
@@ -423,7 +423,7 @@ describe('#generic', () => {
           const messages = msgsToArr(incomingMessage)
           receivedMessages.push(...messages)
 
-          if (!closed && receivedMessages.length === 2) {
+          if (!closed && receivedMessages.length === 20) {
             closed = true
             consumerStream.close()
           }
@@ -438,7 +438,7 @@ describe('#generic', () => {
         const topic = 'test-throw-kafka-error-like'
 
         producer = await createProducerStream(service)
-        await sendMessages(producer, topic, 10)
+        await sendMessages(producer, topic, 40)
 
         consumerStream = await createConsumerStream(service, {
           streamOptions: {
@@ -458,7 +458,7 @@ describe('#generic', () => {
             receivedMessages.push(...messages)
             const lastMessage = messages[messages.length-1]
 
-            if (!errorEmitted && receivedMessages.length === 2) {
+            if (!errorEmitted && receivedMessages.length === 20) {
               errorEmitted = true
               service.log.debug('EMIT ERROR')
               consumerStream.consumer.emit(
@@ -477,7 +477,7 @@ describe('#generic', () => {
         const topic = 'test-throw-kafka-error-like-stream'
 
         producer = await createProducerStream(service)
-        await sendMessages(producer, topic, 10)
+        await sendMessages(producer, topic, 40)
 
         consumerStream = await createConsumerStream(service, {
           streamOptions: {
@@ -499,7 +499,7 @@ describe('#generic', () => {
             receivedMessages.push(...messages)
             const lastMessage = messages[messages.length-1]
 
-            if (!errorEmitted && receivedMessages.length === 2) {
+            if (!errorEmitted && receivedMessages.length === 20) {
               errorEmitted = true
               consumerStream.consumer.emit(
                 'offset.commit',
@@ -528,7 +528,7 @@ describe('#generic', () => {
         const topic = 'test-throw-kafka-error-handler'
 
         producer = await createProducerStream(service)
-        await sendMessages(producer, topic, 10)
+        await sendMessages(producer, topic, 100)
 
         consumerStream = await createConsumerStream(service, {
           streamOptions: {
@@ -551,7 +551,7 @@ describe('#generic', () => {
             receivedMessages.push(...messages)
             const lastMessage = messages[messages.length-1]
 
-            if (!errorEmitted && receivedMessages.length === 2) {
+            if (!errorEmitted && receivedMessages.length === 20) {
               errorEmitted = true
               service.log.debug('EMIT ERROR')
               emitError(consumerStream, { topic: lastMessage.topic, partition: lastMessage.partition, offset: lastMessage.offset + 1 })
@@ -569,7 +569,7 @@ describe('#generic', () => {
         const topic = 'test-throw-kafka-error-handler-stream'
 
         producer = await createProducerStream(service)
-        await sendMessages(producer, topic, 10)
+        await sendMessages(producer, topic, 40)
 
         consumerStream = await createConsumerStream(service, {
           streamOptions: {
@@ -594,7 +594,7 @@ describe('#generic', () => {
             receivedMessages.push(...messages)
             const lastMessage = messages[messages.length-1]
 
-            if (!errorEmitted && receivedMessages.length === 2) {
+            if (!errorEmitted && receivedMessages.length === 20) {
               errorEmitted = true
               emitError(consumerStream, { topic: lastMessage.topic, partition: lastMessage.partition, offset: lastMessage.offset + 1 })
             }
@@ -612,7 +612,7 @@ describe('#generic', () => {
       const topic = 'test-throw-error-invalid-topic'
 
       producer = await createProducerStream(service)
-      await sendMessages(producer, topic, 10)
+      await sendMessages(producer, topic, 40)
 
       consumerStream = await createConsumerStream(service, {
         streamOptions: {
@@ -632,7 +632,7 @@ describe('#generic', () => {
           const lastMessage = messages[messages.length-1]
           receivedMessages.push(...messages)
 
-          if (!sent && receivedMessages.length === 2) {
+          if (!sent && receivedMessages.length === 20) {
             sent = true
             consumerStream.consumer.commitMessage({
               ...lastMessage,

--- a/packages/plugin-kafka/src/custom/admin-client.ts
+++ b/packages/plugin-kafka/src/custom/admin-client.ts
@@ -106,7 +106,7 @@ export class KafkaAdminClient {
   }
 
   private async waitFor(client: KafkaClient, topicName: string, criteria: WaitCriteria, params?: retry.Options): Promise<TopicMetadata> {
-    const retryParams = merge(this.defaultWaitParams, params)
+    const retryParams = merge(Object.create(null), this.defaultWaitParams, params)
     let attempts = 0
 
     return retry(async () => {

--- a/packages/plugin-kafka/src/custom/consumer-stream.ts
+++ b/packages/plugin-kafka/src/custom/consumer-stream.ts
@@ -1,11 +1,11 @@
 import { Readable } from 'stream'
 import * as assert from 'assert'
 import { once } from 'events'
-import { find, uniqWith, isEqual } from 'lodash'
-import { map, promisify, delay } from 'bluebird'
+import { uniqWith, isEqual } from 'lodash'
+import { promisify, delay } from 'bluebird'
 import type { Logger } from '@microfleet/plugin-logger'
 import type { ConsumerStreamOptions } from '@microfleet/plugin-kafka-types'
-import { KafkaConsumer, Message, TopicPartition, LibrdKafkaError } from './rdkafka-extra'
+import { KafkaConsumer, Message, LibrdKafkaError } from './rdkafka-extra'
 import { OffsetCommitError, CriticalErrors, RetryableErrors, UncommittedOffsetsError, Generic /*, CommitTimeoutError*/ } from './errors'
 import { TopicPartitionOffset, SubscribeTopicList, Assignment, EofEvent } from 'node-rdkafka'
 
@@ -44,6 +44,8 @@ export class KafkaConsumerStream extends Readable {
   // private offsetCommitTimeout: number
   private offsetTracker: CommitOffsetTracker
   private unacknowledgedTracker: CommitOffsetTracker
+  private partitionEofs: CommitOffsetTracker
+
   private log?: Logger
   private endEmitted: boolean
 
@@ -82,6 +84,8 @@ export class KafkaConsumerStream extends Readable {
     // this.offsetCommitTimeout = config.offsetCommitTimeout || 5000
     this.offsetTracker = new Map()
     this.unacknowledgedTracker = new Map()
+    this.partitionEofs = new Map()
+
     this.consumer = consumer
     this.autoStore = config.autoOffsetStore !== false
 
@@ -200,7 +204,20 @@ export class KafkaConsumerStream extends Readable {
   }
 
   public close(cb?: (err?: Error | null, result?: any) => void): void {
-    this.consumer.disconnect(cb)
+    if ((this.endEmitted || this.destroyed || this.consumerDisconnected())) {
+      if (cb) cb()
+      return
+    }
+
+    this.on('error', (err) => {
+      if (cb) cb(err)
+    })
+
+    this.on('close', () => {
+      if (cb) cb()
+    })
+
+    this.consumer.disconnect()
   }
 
   private inDestroyingState(): boolean {
@@ -221,7 +238,7 @@ export class KafkaConsumerStream extends Readable {
     eof.eof = true
 
     this.log?.info({ eof }, 'eof event')
-    this.handleOffsetCommit(null, [eof])
+    await this.updatePartitionEof(eof, this.partitionEofs)
   }
 
   private async handleOffsetCommit(err: LibrdKafkaError | null | undefined , partitions: TopicPartitionOffset[]): Promise<void> {
@@ -293,7 +310,10 @@ export class KafkaConsumerStream extends Readable {
     this.log?.debug({ err, assignments }, 'rebalance')
     switch (err.code) {
       case Generic.ERR__ASSIGN_PARTITIONS:
-        this.updatePartitionOffsets(assignments, this.offsetTracker)
+        // eslint-disable-next-line no-case-declarations
+        const committedOffsets = await this.consumer.committedAsync(assignments, this.offsetQueryTimeout)
+        this.log?.debug({ committedOffsets }, 'Check previous committed offsets')
+        this.updatePartitionOffsets(committedOffsets, this.offsetTracker)
         this.consumer.assign(assignments)
         break
 
@@ -302,6 +322,7 @@ export class KafkaConsumerStream extends Readable {
         if (!this.consumerDisconnected()) {
           this.cleanPartitionOffsets(assignments, this.offsetTracker)
           this.cleanPartitionOffsets(assignments, this.unacknowledgedTracker)
+          this.cleanPartitionOffsets(assignments, this.partitionEofs)
         }
         break
 
@@ -433,47 +454,6 @@ export class KafkaConsumerStream extends Readable {
   }
 
   /**
-   * Detects EOF on consumed topic partitions
-   * @deprecated - we are listening to partition.eof method instead now
-   */
-  public async allMessagesRead(): Promise<boolean> {
-    const { consumer } = this
-
-    const assignments: TopicPartition[] = consumer.assignments()
-
-    if (assignments.length === 0) {
-      this.log?.debug('allMessagesRead no assignments')
-      return true
-    }
-
-    const localPositions = await this.getPositions(assignments)
-    const remoteOffsets = await map(assignments, async ({ topic, partition }) => {
-      const offsets = await consumer.queryWatermarkOffsetsAsync(topic, partition, this.offsetQueryTimeout)
-
-      return {
-        topic,
-        partition,
-        ...offsets,
-      }
-    })
-
-    const partitionStatus = remoteOffsets.map((offsetInfo: any) => {
-      const { highOffset, topic, partition } = offsetInfo
-      const localPosition = find(localPositions, { topic, partition })
-
-      if (!localPosition) return false
-      // remote high offset is 0 when there is no data in topic
-      // client offset is -1001 when no data read
-      const localOffset = localPosition.offset === UNKNOWN_OFFSET ? 0 : localPosition.offset
-      return localPosition ? highOffset === localOffset : false
-    })
-
-    this.log?.debug({ result: !partitionStatus.includes(false), remoteOffsets, localPositions }, 'allMessagesRead')
-
-    return !partitionStatus.includes(false)
-  }
-
-  /**
    * Determines whether we have outstanding acknowledgements to be written
    * to the broker
    */
@@ -499,31 +479,25 @@ export class KafkaConsumerStream extends Readable {
     return false
   }
 
-  /**
-   * Gets consumer committed partitions positions from broker
-   */
-  private async getPositions(assignments: Assignment[]): Promise<TopicPartitionOffset[]> {
-    const commitedAssignments = await this.consumer.committedAsync(assignments, this.offsetQueryTimeout)
-    const commitedOffsets: TopicPartitionOffset[] = commitedAssignments.map((assignment: Assignment) => {
-      const key = KafkaConsumerStream.trackingKey(assignment)
+  private async updatePartitionEof(topicPartition: TopicPartitionOffset, map: CommitOffsetTracker): Promise<void> {
+      const trackingKey = KafkaConsumerStream.trackingKey(topicPartition)
 
-      if (isTopicPartitionOffset(assignment)) {
-        this.offsetTracker.set(key, assignment)
-        return assignment
+      map.set(trackingKey, topicPartition)
+
+      const currentOffsetData = this.offsetTracker.get(trackingKey)
+      const currentOffset = currentOffsetData?.offset || UNKNOWN_OFFSET
+
+      if (
+        currentOffsetData && (
+          currentOffset === topicPartition.offset || currentOffset === UNKNOWN_OFFSET
+        )
+      ) {
+        currentOffsetData.eof = true
       }
 
-      const offset = {
-        topic: assignment.topic,
-        partition: assignment.partition,
-        offset: UNKNOWN_OFFSET
+      if (!this.hasOutstandingAcks()) {
+        await this.checkEof()
       }
-
-      this.offsetTracker.set(key, offset)
-      return offset
-    })
-
-    this.log?.debug({ commitedOffsets }, 'positions')
-    return commitedOffsets
   }
 
   private updatePartitionOffsets(partitions: Assignment[], map: CommitOffsetTracker): void {
@@ -535,10 +509,8 @@ export class KafkaConsumerStream extends Readable {
         const currentOffsetData = map.get(trackingKey)
         const currentOffset = currentOffsetData?.offset || UNKNOWN_OFFSET
 
-        if (currentOffset < topicPartition.offset || !currentOffsetData) {
+        if (currentOffset <= topicPartition.offset || !currentOffsetData) {
           map.set(KafkaConsumerStream.trackingKey(topicPartition), topicPartition)
-        } else if (currentOffset === topicPartition.offset && topicPartition.eof) {
-          currentOffsetData.eof = true
         }
       // if it has no offset - means its a new assignment, set offset to -1001
       } else if (!map.has(trackingKey)) {

--- a/packages/plugin-kafka/src/kafka.ts
+++ b/packages/plugin-kafka/src/kafka.ts
@@ -86,9 +86,7 @@ export class KafkaFactory {
       ...opts.conf,
       offset_commit_cb: opts.conf?.offset_commit_cb || true,
       // consumer stream manages assign/unassing so we should pass function as callback
-      rebalance_cb: typeof opts.conf?.rebalance_cb === 'function'
-        ? opts.conf?.rebalance_cb
-        : noop,
+      rebalance_cb: typeof opts.conf?.rebalance_cb === 'function' ? opts.conf?.rebalance_cb : noop,
       'enable.auto.offset.store': false,
       'enable.partition.eof': true, // new feature, allows us to listen to eof event
     }

--- a/packages/plugin-kafka/src/kafka.ts
+++ b/packages/plugin-kafka/src/kafka.ts
@@ -28,6 +28,7 @@ import {
 import { getLogFnName, topicExists } from './util'
 import { KafkaConsumerStream } from './custom/consumer-stream'
 import { KafkaAdminClient } from './custom/admin-client'
+import { noop } from 'lodash'
 
 export { OffsetCommitError, UncommittedOffsetsError, TopicNotFoundError } from './custom/errors'
 export { DeleteTopicRequest, CreateTopicRequest, RetryOptions } from './custom/admin-client'
@@ -84,7 +85,10 @@ export class KafkaFactory {
     const consumerConfig: ConsumerStreamConfig['conf'] = {
       ...opts.conf,
       offset_commit_cb: opts.conf?.offset_commit_cb || true,
-      rebalance_cb: opts.conf?.rebalance_cb || true,
+      // consumer stream manages assign/unassing so we should pass function as callback
+      rebalance_cb: typeof opts.conf?.rebalance_cb === 'function'
+        ? opts.conf?.rebalance_cb
+        : noop,
       'enable.auto.offset.store': false,
       'enable.partition.eof': true, // new feature, allows us to listen to eof event
     }


### PR DESCRIPTION
EOF event handler should not update currently tracked offsets, otherwise it hangs in read loop or performs early exit without full message processing.