### PR TITLE
feat(plugin-logger): sentry fingerprinting

### DIFF
--- a/packages/plugin-logger/src/logger/streams/sentry.spec.ts
+++ b/packages/plugin-logger/src/logger/streams/sentry.spec.ts
@@ -5,6 +5,7 @@ import { pino } from 'pino'
 import sentryTestkit from 'sentry-testkit'
 import { strict as assert } from 'assert'
 import { setTimeout } from 'timers/promises'
+import { SENTRY_FINGERPRINT_DEFAULT } from '../../constants'
 
 describe('Logger Sentry Stream Suite', () => {
   const sandbox = createSandbox()
@@ -63,7 +64,13 @@ describe('Logger Sentry Stream Suite', () => {
 
     const logger = pino({ level: 'debug' }, pinoms)
 
-    logger.warn({ userId: 123, tags: { testTag: 'test' }, extras: { someData: 'test' }, user: { id: 1234 } }, 'Warning message')
+    logger.warn({
+      userId: 123,
+      tags: { testTag: 'test' },
+      extras: { someData: 'test' },
+      user: { id: 1234 },
+      fingerprint: [SENTRY_FINGERPRINT_DEFAULT, 'test'],
+    }, 'Warning message')
     logger.flush()
 
     await Sentry.flush()
@@ -80,6 +87,7 @@ describe('Logger Sentry Stream Suite', () => {
       _user: { id: 1234 },
       _tags: { testTag: 'test' },
       _extra: { someData: 'test' },
+      _fingerprint: ['{{ default }}', 'test'],
       _contexts: {},
       _sdkProcessingMetadata: {},
       _level: 'warning'

--- a/packages/plugin-logger/src/logger/streams/sentry.ts
+++ b/packages/plugin-logger/src/logger/streams/sentry.ts
@@ -67,12 +67,15 @@ export async function sentryTransport({ externalConfiguration, sentry, minLevel 
 
   return build(async function (source) {
     for await (const obj of source) {
-      const { level, tags, extras, user } = obj
+      const { level, tags, extras, user, fingerprint } = obj
       const scope = new Sentry.Scope()
       scope.setLevel(pinoLevelToSentryLevel(level))
       scope.setExtras(extras)
       scope.setUser(user)
       scope.setTags(tags)
+      if (fingerprint) {
+        scope.setFingerprint(fingerprint);
+      }
 
       // extend scope with enumerable error properties if they exist, omit manually processed ones
       if (obj.err) {


### PR DESCRIPTION
Sentry Fingerprint allows to group messages together into an issue. Its value is represented by array of strings. The default Sentry value is `["{{ default }}"]`. It is assumed that the custom fingerprint is not empty, otherwise it is ignored. The Sentry SDK validates the value itself.